### PR TITLE
Specify compression method as 0 (STORE)

### DIFF
--- a/lib/download-job.tsx
+++ b/lib/download-job.tsx
@@ -104,7 +104,7 @@ export const createDownloadJob = async (result: QobuzAlbum | QobuzTrack, setStat
                         trackBlobs.push(new Blob([outputFile]));
                     }
                     setStatusBar(statusBar => ({ ...statusBar, progress: 0, description: `Zipping album...` }));
-                    const zipWriter = new zip.ZipWriter(new zip.BlobWriter("application/zip"), { bufferedWrite: true, compressionMethod: 0 });
+                    const zipWriter = new zip.ZipWriter(new zip.BlobWriter("application/zip"), { bufferedWrite: true, level: 0 });
                     for (const [index, blob] of trackBlobs.entries()) {
                         const fileName = (index + 1).toString().padStart((albumTracks.length - 1).toString().length > 2 ? (albumTracks.length - 1).toString().length : 2, '0') + " " + formatTitle(albumTracks[index]) + "." + codecMap[settings.outputCodec].extension
                         await zipWriter.add(cleanFileName(fileName), new zip.BlobReader(blob), { signal });

--- a/lib/download-job.tsx
+++ b/lib/download-job.tsx
@@ -104,7 +104,7 @@ export const createDownloadJob = async (result: QobuzAlbum | QobuzTrack, setStat
                         trackBlobs.push(new Blob([outputFile]));
                     }
                     setStatusBar(statusBar => ({ ...statusBar, progress: 0, description: `Zipping album...` }));
-                    const zipWriter = new zip.ZipWriter(new zip.BlobWriter("application/zip"), { bufferedWrite: true });
+                    const zipWriter = new zip.ZipWriter(new zip.BlobWriter("application/zip"), { bufferedWrite: true, compressionMethod: 0 });
                     for (const [index, blob] of trackBlobs.entries()) {
                         const fileName = (index + 1).toString().padStart((albumTracks.length - 1).toString().length > 2 ? (albumTracks.length - 1).toString().length : 2, '0') + " " + formatTitle(albumTracks[index]) + "." + codecMap[settings.outputCodec].extension
                         await zipWriter.add(cleanFileName(fileName), new zip.BlobReader(blob), { signal });


### PR DESCRIPTION
Since all the FLACs are downloaded to user's memory, and then ffmpeg is used to splice in the metadata, the data is already local to the user.

As such, there is not much value in compressing the ZIP file. 

Per the docs, we can use level 0 to effectively STORE the content in the zip (i.e. just a single file container): https://gildas-lormeau.github.io/zip.js/api/interfaces/ZipWriterConstructorOptions.html#level

This can reduce CPU bottlenecks when downloading albums (especially on mobile devices)