### PR TITLE
Added CORS Proxy Support

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,5 @@ QOBUZ_AUTH_TOKENS = []
 NEXT_PUBLIC_GITHUB = https://github.com/QobuzDL/Qobuz-DL
 NEXT_PUBLIC_DISCORD = https://discord.gg/invite/GN7GnntyQ2
 NEXT_PUBLIC_APPLICATION_NAME = Qobuz-DL
+
+USE_CORS_PROXY = true

--- a/lib/qobuz-dl.tsx
+++ b/lib/qobuz-dl.tsx
@@ -142,13 +142,14 @@ export async function search(query: string, limit: number = 10, offset: number =
     url.searchParams.append("query", query)
     url.searchParams.append("limit", limit.toString());
     url.searchParams.append("offset", offset.toString());
-    const response = await axios.get(url.toString(), {
+    const response = await axios.get(process.env.USE_CORS_PROXY?.toLowerCase() === "true" ? "https://corsproxy.io/?url=" + encodeURIComponent(url.toString()) : url.toString(), {
         headers: {
             "x-app-id": process.env.QOBUZ_APP_ID!,
-            "x-user-auth-token": getRandomToken()
+            "x-user-auth-token": getRandomToken(),
+            "User-Agent": process.env.USE_CORS_PROXY?.toLowerCase() === "true" ? "Qobuz-DL" : undefined
         }
     });
-    return response.data as QobuzSearchResults;
+    return response!.data as QobuzSearchResults;
 }
 
 export async function getDownloadURL(trackID: number, quality: string) {
@@ -165,10 +166,11 @@ export async function getDownloadURL(trackID: number, quality: string) {
     const headers = new Headers();
     headers.append('X-App-Id', process.env.QOBUZ_APP_ID!);
     headers.append("X-User-Auth-Token", getRandomToken());
-    const response = await axios.get(url.toString(), {
+    const response = await axios.get(process.env.USE_CORS_PROXY?.toLowerCase() === "true" ? "https://corsproxy.io/?url=" + encodeURIComponent(url.toString()) : url.toString(), {
         headers: {
             "x-app-id": process.env.QOBUZ_APP_ID!,
-            "x-user-auth-token": getRandomToken()
+            "x-user-auth-token": getRandomToken(),
+            "User-Agent": process.env.USE_CORS_PROXY?.toLowerCase() === "true" ? "Qobuz-DL" : undefined
         }
     })
     return response.data.url;
@@ -179,10 +181,11 @@ export async function getAlbumInfo(album_id: string) {
     const url = new URL(process.env.QOBUZ_API_BASE + 'album/get');
     url.searchParams.append("album_id", album_id);
     url.searchParams.append("extra", "track_ids");
-    const response = await axios.get(url.toString(), {
+    const response = await axios.get(process.env.USE_CORS_PROXY?.toLowerCase() === "true" ? "https://corsproxy.io/?url=" + encodeURIComponent(url.toString()) : url.toString(), {
         headers: {
             "x-app-id": process.env.QOBUZ_APP_ID!,
-            "x-user-auth-token": getRandomToken()
+            "x-user-auth-token": getRandomToken(),
+            "User-Agent": process.env.USE_CORS_PROXY?.toLowerCase() === "true" ? "Qobuz-DL" : undefined
         }
     })
     return response.data;


### PR DESCRIPTION
Added support for corsproxy.io - a free proxy for those whose IP is blocked by Qobuz. To use it, set USE_CORS_PROXY in the .env file to "true".