### PR TITLE
feat: Add complete playlist support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,6 @@
-QOBUZ_API_BASE = https://www.qobuz.com/api.json/0.2/
-QOBUZ_APP_ID = 
-QOBUZ_SECRET = 
-QOBUZ_AUTH_TOKENS = []
-
-NEXT_PUBLIC_APPLICATION_NAME = Qobuz-DL
-NEXT_PUBLIC_GITHUB = https://github.com/QobuzDL/Qobuz-DL
-
-#Leave these empty unless you know what you're doing
-CORS_PROXY = 
-SOCKS5_PROXY = 
+QOBUZ_API_BASE=https://www.qobuz.com/api.json/0.2/
+QOBUZ_APP_ID=your_app_id_here
+QOBUZ_AUTH_TOKENS=["your_token_here"]
+QOBUZ_SECRET=your_secret_here
+QOBUZ_COUNTRY_LIST=[{"name":"Germany","code":"de","token":"your_token"}]
+NEXT_PUBLIC_APPLICATION_NAME=Qobuz-DL

--- a/app/api/get-playlist/route.ts
+++ b/app/api/get-playlist/route.ts
@@ -1,0 +1,48 @@
+import { getPlaylistInfo } from '@/lib/qobuz-dl-server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+    const searchParams = request.nextUrl.searchParams;
+    let playlist_id = searchParams.get('playlist_id');
+    const q = searchParams.get('q');
+    const country = request.headers.get('Token-Country') || undefined;
+    
+    // If q parameter is provided (from search), extract playlist ID
+    if (q && !playlist_id) {
+        const QOBUZ_PLAYLIST_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/playlist\/(\d+)/;
+        const match = q.match(QOBUZ_PLAYLIST_URL_REGEX);
+        if (match) {
+            playlist_id = match[2];
+        } else if (/^\d+$/.test(q)) {
+            // If it's just numbers, use as playlist_id
+            playlist_id = q;
+        }
+    }
+    
+    if (!playlist_id) {
+        return NextResponse.json({ error: 'Missing playlist_id parameter' }, { status: 400 });
+    }
+    
+    try {
+        const data = await getPlaylistInfo(playlist_id, { country });
+        
+        // Return in search results format
+        return NextResponse.json({ 
+            success: true,
+            data: {
+                query: q || playlist_id,
+                switchTo: 'playlists',
+                albums: { limit: 0, offset: 0, total: 0, items: [] },
+                tracks: { limit: 0, offset: 0, total: 0, items: [] },
+                artists: { limit: 0, offset: 0, total: 0, items: [] },
+                playlists: { limit: 1, offset: 0, total: 1, items: [data] }
+            }
+        });
+    } catch (error: any) {
+        console.error('Error fetching playlist:', error);
+        return NextResponse.json(
+            { error: error.response?.data || error.message },
+            { status: error.response?.status || 500 }
+        );
+    }
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,29 @@
+// app/api/search/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+
+const QOBUZ_APP_ID = process.env.QOBUZ_APP_ID!;
+const QOBUZ_AUTH_TOKEN = process.env.QOBUZ_AUTH_TOKENS!;
+const QOBUZ_API_BASE = 'https://www.qobuz.com/api.json/0.2';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const query = searchParams.get('q');
+  const type = searchParams.get('type') || 'track';
+
+  if (!query) {
+    return NextResponse.json({ error: 'Missing search query' }, { status: 400 });
+  }
+
+  const apiUrl = `${QOBUZ_API_BASE}/search/${type}?app_id=${QOBUZ_APP_ID}&user_auth_token=${QOBUZ_AUTH_TOKEN}&query=${encodeURIComponent(query)}`;
+
+  try {
+    const response = await fetch(apiUrl);
+    const data = await response.json();
+
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('[Qobuz API error]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/search-view.tsx
+++ b/app/search-view.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import ReleaseCard from '@/components/release-card';
 import SearchBar from '@/components/search-bar/search-bar';
 import { Button } from '@/components/ui/button';
-import { Disc3Icon, DiscAlbumIcon, UsersIcon } from 'lucide-react';
+import { Disc3Icon, DiscAlbumIcon, ListMusicIcon, UsersIcon } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { FilterDataType, filterExplicit, QobuzAlbum, QobuzArtist, QobuzSearchFilters, QobuzSearchResults, QobuzTrack } from '@/lib/qobuz-dl';
 import { getTailwindBreakpoint } from '@/lib/utils';
@@ -32,6 +32,12 @@ export const filterData: FilterDataType = [
         label: 'Artists',
         value: 'artists',
         icon: UsersIcon
+    },
+    {
+        label: 'Playlists',
+        value: 'playlists',
+        searchRoute: 'get-playlist',
+        icon: ListMusicIcon
     }
 ];
 

--- a/components/download-playlist-button.tsx
+++ b/components/download-playlist-button.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { Button, ButtonProps } from './ui/button';
+import { DownloadIcon, FileArchiveIcon, MusicIcon } from 'lucide-react';
+import { StatusBarProps } from './status-bar/status-bar';
+import { FFmpegType } from '@/lib/ffmpeg-functions';
+import { SettingsProps } from '@/lib/settings-provider';
+import { FetchedQobuzAlbum, formatTitle, QobuzPlaylist } from '@/lib/qobuz-dl';
+import { createDownloadJob } from '@/lib/download-job';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu';
+import { useCountry } from '@/lib/country-provider';
+
+export interface DownloadPlaylistButtonProps extends ButtonProps {
+    result: QobuzPlaylist;
+    setStatusBar: React.Dispatch<React.SetStateAction<StatusBarProps>>;
+    ffmpegState: FFmpegType;
+    settings: SettingsProps;
+    fetchedAlbumData: FetchedQobuzAlbum | null;
+    setFetchedAlbumData: React.Dispatch<React.SetStateAction<FetchedQobuzAlbum | null>>;
+    fetchedPlaylistData?: QobuzPlaylist | null;
+    onOpen?: () => void;
+    onClose?: () => void;
+    toast: (toast: any) => void;
+}
+
+const DownloadPlaylistButton = React.forwardRef<HTMLButtonElement, DownloadPlaylistButtonProps>(
+    (
+        {
+            className,
+            variant,
+            size,
+            asChild = false,
+            onOpen,
+            onClose,
+            result,
+            setStatusBar,
+            ffmpegState,
+            settings,
+            toast,
+            fetchedAlbumData,
+            setFetchedAlbumData,
+            fetchedPlaylistData,
+            ...props
+        },
+        ref
+    ) => {
+        const { country } = useCountry();
+        const [open, setOpen] = useState(false);
+        useEffect(() => {
+            if (open) onOpen?.();
+            else onClose?.();
+        });
+        return (
+            <>
+                <DropdownMenu open={open} onOpenChange={setOpen}>
+                    <DropdownMenuTrigger asChild>
+                        <Button className={className} ref={ref} variant={variant} size={size} asChild={asChild} {...props}>
+                            <DownloadIcon className='!size-4' />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                        <DropdownMenuItem
+                            onClick={() => {
+                                createDownloadJob(result, setStatusBar, ffmpegState, settings, toast, fetchedAlbumData, setFetchedAlbumData, country);
+                                toast({
+                                    title: `Added '${formatTitle(result)}'`,
+                                    description: 'The playlist has been added to the queue'
+                                });
+                            }}
+                            className='flex items-center gap-2'
+                        >
+                            <FileArchiveIcon className='!size-4' />
+                            <p>ZIP Archive</p>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                            onClick={async () => {
+                                const playlist = fetchedPlaylistData || result;
+                                if (!playlist.tracks || !playlist.tracks.items) {
+                                    toast({
+                                        title: 'Error',
+                                        description: 'Please open the tracklist first to load playlist data'
+                                    });
+                                    return;
+                                }
+                                for (const track of playlist.tracks.items) {
+                                    if (track.streamable) {
+                                        await createDownloadJob(
+                                            track,
+                                            setStatusBar,
+                                            ffmpegState,
+                                            settings,
+                                            toast,
+                                            fetchedAlbumData,
+                                            setFetchedAlbumData,
+                                            country
+                                        );
+                                        await new Promise((resolve) => setTimeout(resolve, 100));
+                                    }
+                                }
+                                toast({
+                                    title: `Added '${formatTitle(result)}'`,
+                                    description: 'The playlist has been added to the queue'
+                                });
+                            }}
+                            className='flex items-center gap-2'
+                        >
+                            <MusicIcon className='!size-4' />
+                            <p>No ZIP Archive</p>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </>
+        );
+    }
+);
+DownloadPlaylistButton.displayName = 'DownloadPlaylistButton';
+
+export default DownloadPlaylistButton;

--- a/components/release-card.tsx
+++ b/components/release-card.tsx
@@ -1,5 +1,7 @@
+import axios from 'axios';
 import ArtistDialog from './artist-dialog';
 import DownloadAlbumButton from './download-album-button';
+import DownloadPlaylistButton from './download-playlist-button';
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import { AlignJustifyIcon, DotIcon, DownloadIcon, UsersIcon, DiscAlbumIcon } from 'lucide-react';
@@ -17,6 +19,7 @@ import {
     getType,
     QobuzAlbum,
     QobuzArtist,
+    QobuzPlaylist,
     QobuzTrack
 } from '@/lib/qobuz-dl';
 import { filterData } from '@/app/search-view';
@@ -36,11 +39,12 @@ const ReleaseCard = ({
     ref,
     showArtistDialog
 }: {
-    result: QobuzAlbum | QobuzTrack | QobuzArtist;
+    result: QobuzAlbum | QobuzTrack | QobuzArtist | QobuzPlaylist;
     resolvedTheme: string;
     ref?: React.Ref<HTMLDivElement>;
     showArtistDialog?: boolean;
 }) => {
+    const isPlaylist = 'owner' in result;
     if (typeof showArtistDialog === 'undefined') showArtistDialog = true;
     const { ffmpegState } = useFFmpeg();
     const { setStatusBar } = useStatusBar();
@@ -48,11 +52,12 @@ const ReleaseCard = ({
 
     const [openTracklist, setOpenTracklist] = useState(false);
     const [fetchedAlbumData, setFetchedAlbumData] = useState<FetchedQobuzAlbum | null>(null);
+    const [fetchedPlaylistData, setFetchedPlaylistData] = useState<QobuzPlaylist | null>(null);
     const [focusCard, setFocusCard] = useState(false);
 
     const { toast } = useToast();
 
-    const album = getAlbum(result) || null;
+    const album = isPlaylist ? null : (getAlbum(result) || null);
 
     const [imageLoaded, setImageLoaded] = useState(false);
     const imageAnimationControls = useAnimation();
@@ -84,12 +89,14 @@ const ReleaseCard = ({
                         <div className='space-y-0.5 p-4 flex justify-between relative overflow-x-hidden'>
                             <div className='w-full pr-9'>
                                 <p className='text-sm truncate capitalize font-bold'>
-                                    {!(getType(result) === 'artists') ? album.genre.name : (result as QobuzArtist).albums_count + ' Releases'}
+                                    {getType(result) === 'artists' ? (result as QobuzArtist).albums_count + ' Releases' : 
+                                     isPlaylist ? (result as QobuzPlaylist).tracks_count + ' tracks' : 
+                                     album?.genre?.name || 'Unknown'}
                                 </p>
-                                {!(getType(result) === 'artists') && (
+                                {!isPlaylist && !(getType(result) === 'artists') && album && (
                                     <p className='text-xs truncate capitalize font-medium'>{new Date(album.released_at * 1000).getFullYear()}</p>
                                 )}
-                                {!(getType(result) === 'artists') && (
+                                {!isPlaylist && !(getType(result) === 'artists') && (
                                     <div className='flex text-[10px] truncate font-semibold items-center justify-start'>
                                         <p>{(result as QobuzAlbum | QobuzTrack).maximum_bit_depth}-bit</p>
                                         <DotIcon size={16} />
@@ -97,18 +104,18 @@ const ReleaseCard = ({
                                     </div>
                                 )}
                                 <div className='flex text-[10px] truncate font-semibold items-center justify-start'>
-                                    {(result as QobuzAlbum).tracks_count ? (
+                                    {((result as QobuzAlbum).tracks_count || (result as QobuzPlaylist).tracks_count) ? (
                                         <>
                                             <p>
-                                                {(result as QobuzAlbum).tracks_count} {(result as QobuzAlbum).tracks_count > 1 ? 'tracks' : 'track'}
+                                                {(result as QobuzAlbum | QobuzPlaylist).tracks_count} {(result as QobuzAlbum | QobuzPlaylist).tracks_count > 1 ? 'tracks' : 'track'}
                                             </p>
                                             <DotIcon size={16} />
                                         </>
                                     ) : null}
-                                    {!(getType(result) === 'artists') && <p>{formatDuration((result as QobuzAlbum | QobuzTrack).duration)}</p>}
+                                    {!(getType(result) === 'artists') && <p>{formatDuration((result as QobuzAlbum | QobuzTrack | QobuzPlaylist).duration)}</p>}
                                 </div>
                             </div>
-                            {getType(result) !== 'artists' && showArtistDialog && (
+                            {getType(result) !== 'artists' && !isPlaylist && showArtistDialog && (
                                 <div className='absolute top-0 right-0 p-4'>
                                     <Button
                                         size='icon'
@@ -125,7 +132,7 @@ const ReleaseCard = ({
                         </div>
                         {!(getType(result) === 'artists') && (
                             <div className='flex items-center justify-between gap-4 p-2'>
-                                {(result as QobuzTrack).album ? (
+                                {!isPlaylist && (result as QobuzTrack).album ? (
                                     <Button
                                         size='icon'
                                         variant='ghost'
@@ -144,7 +151,7 @@ const ReleaseCard = ({
                                     >
                                         <DownloadIcon />
                                     </Button>
-                                ) : (
+                                ) : !isPlaylist ? (
                                     <DownloadAlbumButton
                                         variant='ghost'
                                         size='icon'
@@ -158,30 +165,55 @@ const ReleaseCard = ({
                                         onOpen={() => setFocusCard(true)}
                                         onClose={() => setFocusCard(false)}
                                     />
-                                )}
-                                {(result as QobuzTrack).album ? null : (
-                                    <Button
-                                        size='icon'
+                                ) : (
+                                    <DownloadPlaylistButton
                                         variant='ghost'
-                                        onClick={async () => {
-                                            setOpenTracklist(!openTracklist);
-                                            await getFullAlbumInfo(fetchedAlbumData, setFetchedAlbumData, result as QobuzAlbum, country);
-                                        }}
-                                    >
-                                        <AlignJustifyIcon />
-                                    </Button>
+                                        size='icon'
+                                        result={result as QobuzPlaylist}
+                                        toast={toast}
+                                        setStatusBar={setStatusBar}
+                                        ffmpegState={ffmpegState}
+                                        settings={settings}
+                                        fetchedAlbumData={fetchedAlbumData}
+                                        setFetchedAlbumData={setFetchedAlbumData}
+                                        fetchedPlaylistData={fetchedPlaylistData}
+                                        onOpen={() => setFocusCard(true)}
+                                        onClose={() => setFocusCard(false)}
+                                    />
                                 )}
+                                <Button
+                                    size='icon'
+                                    variant='ghost'
+                                    onClick={async () => {
+                                        setOpenTracklist(!openTracklist);
+                                        if (isPlaylist && !fetchedPlaylistData) {
+                                            try {
+                                                const response = await axios.get('/api/get-playlist', {
+                                                    params: { playlist_id: (result as QobuzPlaylist).id },
+                                                    headers: { 'Token-Country': country }
+                                                });
+                                                setFetchedPlaylistData(response.data.data);
+                                            } catch (error) {
+                                                console.error('Error loading playlist:', error);
+                                            }
+                                        } else if (!isPlaylist) {
+                                            await getFullAlbumInfo(fetchedAlbumData, setFetchedAlbumData, result as QobuzAlbum, country);
+                                        }
+                                    }}
+                                >
+                                    <AlignJustifyIcon />
+                                </Button>
                             </div>
                         )}
                     </div>
                 </div>
                 <motion.div
-                    initial={(album || result).image?.small ? { scale: 0.9 } : { scale: 1 }}
+                    initial={(album || result).image?.small || (result as QobuzPlaylist).images?.[0] ? { scale: 0.9 } : { scale: 1 }}
                     animate={imageAnimationControls}
                     transition={{ duration: 0.1 }}
                     className={cn('absolute left-0 top-0 z-[2] w-full aspect-square transition-all')}
                 >
-                    {(album || result).image?.small ? (
+                    {(album || result).image?.small || (result as QobuzPlaylist).images?.[0] ? (
                         <>
                             {getType(result) === 'artists' ? (
                                 <Image
@@ -201,7 +233,7 @@ const ReleaseCard = ({
                             ) : (
                                 <img
                                     crossOrigin='anonymous'
-                                    src={(album || result).image?.small}
+                                    src={(album || result).image?.small || (result as QobuzPlaylist).images?.[0]}
                                     alt={formatTitle(result)}
                                     className={cn(
                                         'object-cover group-hover:scale-105 transition-all w-full h-full text-[0px]',
@@ -239,10 +271,16 @@ const ReleaseCard = ({
                     )}
                     <h1 className='text-sm truncate font-bold group-hover:underline'>{formatTitle(result)}</h1>
                 </div>
-                {!(getType(result) === 'artists') && (
+                {!(getType(result) === 'artists') && !isPlaylist && (
                     <div className='text-xs truncate flex gap-x-0.5 items-center' title={formatArtists(result as QobuzAlbum | QobuzTrack)}>
                         <UsersIcon className='size-3.5 shrink-0' />
                         <span className='truncate'>{formatArtists(result as QobuzAlbum | QobuzTrack)}</span>
+                    </div>
+                )}
+                {isPlaylist && (
+                    <div className='text-xs truncate flex gap-x-0.5 items-center' title={formatArtists(result as QobuzPlaylist)}>
+                        <UsersIcon className='size-3.5 shrink-0' />
+                        <span className='truncate'>By {formatArtists(result as QobuzPlaylist)}</span>
                     </div>
                 )}
                 {(result as QobuzTrack).album?.title ? (
@@ -258,9 +296,9 @@ const ReleaseCard = ({
                     <div className='flex gap-3 overflow-hidden'>
                         <div className='relative shrink-0 aspect-square min-w-[100px] min-h-[100px] rounded-sm overflow-hidden'>
                             <Skeleton className='absolute aspect-square w-full h-full' />
-                            {(album || result).image?.small && (
+                            {((album || result).image?.small || (result as QobuzPlaylist).images?.[0]) && (
                                 <img
-                                    src={(album || result).image?.small}
+                                    src={(album || result).image?.small || (result as QobuzPlaylist).images?.[0]}
                                     alt={formatTitle(result)}
                                     crossOrigin='anonymous'
                                     className='absolute aspect-square w-full h-full'
@@ -273,9 +311,14 @@ const ReleaseCard = ({
                                 <DialogTitle title={formatTitle(album || result)} className='truncate overflow-visible py-0.5 pr-2'>
                                     {formatTitle(album || result)}
                                 </DialogTitle>
-                                {!(getType(result) === 'artists') && (
+                                {!(getType(result) === 'artists') && !isPlaylist && (
                                     <DialogDescription title={formatArtists(result as QobuzAlbum | QobuzTrack)} className='truncate overflow-visible '>
                                         {formatArtists(result as QobuzAlbum | QobuzTrack)}
+                                    </DialogDescription>
+                                )}
+                                {isPlaylist && (
+                                    <DialogDescription title={formatArtists(result as QobuzPlaylist)} className='truncate overflow-visible '>
+                                        By {formatArtists(result as QobuzPlaylist)}
                                     </DialogDescription>
                                 )}
                             </div>
@@ -283,34 +326,36 @@ const ReleaseCard = ({
                                 <div className='space-y-1.5 w-fit'>
                                     {!(getType(result) === 'artists') && (
                                         <DialogDescription className='truncate'>
-                                            {album.tracks_count} {album.tracks_count > 1 ? 'tracks' : 'track'} - {formatDuration(album.duration)}
+                                            {isPlaylist ? (fetchedPlaylistData?.tracks_count || (result as QobuzPlaylist).tracks_count) : album?.tracks_count} {(isPlaylist ? (fetchedPlaylistData?.tracks_count || (result as QobuzPlaylist).tracks_count) : album?.tracks_count) > 1 ? 'tracks' : 'track'} - {formatDuration(isPlaylist ? (fetchedPlaylistData?.duration || (result as QobuzPlaylist).duration) : album?.duration || 0)}
                                         </DialogDescription>
                                     )}
                                 </div>
-                                <DownloadAlbumButton
-                                    result={result as QobuzAlbum}
-                                    toast={toast}
-                                    setStatusBar={setStatusBar}
-                                    ffmpegState={ffmpegState}
-                                    settings={settings}
-                                    fetchedAlbumData={fetchedAlbumData}
-                                    setFetchedAlbumData={setFetchedAlbumData}
-                                    variant='ghost'
-                                    size='icon'
-                                    onClick={() => {
-                                        setOpenTracklist(false);
-                                    }}
-                                />
+                                {!isPlaylist && (
+                                    <DownloadAlbumButton
+                                        result={result as QobuzAlbum}
+                                        toast={toast}
+                                        setStatusBar={setStatusBar}
+                                        ffmpegState={ffmpegState}
+                                        settings={settings}
+                                        fetchedAlbumData={fetchedAlbumData}
+                                        setFetchedAlbumData={setFetchedAlbumData}
+                                        variant='ghost'
+                                        size='icon'
+                                        onClick={() => {
+                                            setOpenTracklist(false);
+                                        }}
+                                    />
+                                )}
                             </div>
                         </div>
                     </div>
                     <Separator />
-                    {fetchedAlbumData && (
+                    {(fetchedAlbumData || (isPlaylist && fetchedPlaylistData)) && (
                         <ScrollArea className='max-h-[40vh]'>
                             <motion.div initial={{ maxHeight: '0vh' }} animate={{ maxHeight: '40vh' }}>
                                 <div className='flex flex-col overflow-hidden pr-3'>
-                                    {fetchedAlbumData.tracks.items.map((track: QobuzTrack, index: number) => {
-                                        track.album = album;
+                                    {(isPlaylist ? fetchedPlaylistData!.tracks.items : fetchedAlbumData!.tracks.items).map((track: QobuzTrack, index: number) => {
+                                        if (!isPlaylist) track.album = album!;
                                         return (
                                             <div key={track.id}>
                                                 <div
@@ -358,7 +403,7 @@ const ReleaseCard = ({
                                                         </Button>
                                                     )}
                                                 </div>
-                                                {index < fetchedAlbumData.tracks.items.length - 1 && <Separator />}
+                                                {index < (isPlaylist ? fetchedPlaylistData!.tracks.items : fetchedAlbumData!.tracks.items).length - 1 && <Separator />}
                                                 <div />
                                             </div>
                                         );
@@ -369,7 +414,7 @@ const ReleaseCard = ({
                     )}
                 </DialogContent>
             </Dialog>
-            {getType(result) !== 'artists' && showArtistDialog && <ArtistDialog open={openArtistDialog} setOpen={setOpenArtistDialog} artist={artist} />}
+            {getType(result) !== 'artists' && !isPlaylist && showArtistDialog && <ArtistDialog open={openArtistDialog} setOpen={setOpenArtistDialog} artist={artist} />}
         </div>
     );
 };

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,0 +1,6 @@
+export const tokenCountriesMap: TokenCountry[] = [
+  {
+    code: 'DE',
+    token: 'BCwD_1J0fSFxa_yiem5Rpy51GG-M-SPsleFPgSX47YmKLpd5c7sgtiRyzcmooEPxw8dQm3qs1XINAsqISQWgFA'
+  }
+];

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,11 @@
+export async function searchQobuz(query: string, type: 'track' | 'artist' = 'track') {
+  const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&type=${type}`);
+
+  if (!res.ok) {
+    throw new Error(`Fehler beim Abrufen: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data;
+}
+

--- a/lib/download-job.tsx
+++ b/lib/download-job.tsx
@@ -5,14 +5,14 @@ import { artistReleaseCategories } from '@/components/artist-dialog';
 import { cleanFileName, formatBytes, formatCustomTitle, resizeImage } from './utils';
 import { createJob } from './status-bar/jobs';
 import { Disc3Icon, DiscAlbumIcon } from 'lucide-react';
-import { FetchedQobuzAlbum, formatTitle, getFullResImageUrl, QobuzAlbum, QobuzArtistResults, QobuzTrack } from './qobuz-dl';
+import { FetchedQobuzAlbum, formatTitle, getFullResImageUrl, QobuzAlbum, QobuzArtistResults, QobuzPlaylist, QobuzTrack } from './qobuz-dl';
 import { SettingsProps } from './settings-provider';
 import { StatusBarProps } from '@/components/status-bar/status-bar';
 import { ToastAction } from '@/components/ui/toast';
 import { zipSync } from 'fflate';
 
 export const createDownloadJob = async (
-    result: QobuzAlbum | QobuzTrack,
+    result: QobuzAlbum | QobuzTrack | QobuzPlaylist,
     setStatusBar: React.Dispatch<React.SetStateAction<StatusBarProps>>,
     ffmpegState: FFmpegType,
     settings: SettingsProps,
@@ -21,7 +21,9 @@ export const createDownloadJob = async (
     setFetchedAlbumData?: React.Dispatch<React.SetStateAction<FetchedQobuzAlbum | null>>,
     country?: string
 ) => {
+    const isPlaylist = 'owner' in result;
     if ((result as QobuzTrack).album) {
+        // Single track download
         const formattedTitle = formatCustomTitle(settings.trackName, result as QobuzTrack);
         await createJob(setStatusBar, formattedTitle, Disc3Icon, async () => {
             return new Promise(async (resolve) => {
@@ -121,7 +123,8 @@ export const createDownloadJob = async (
             });
         });
     } else {
-        const formattedZipTitle = formatCustomTitle(settings.zipName, result as QobuzAlbum);
+        // Album or Playlist download
+        const formattedZipTitle = isPlaylist ? (result as QobuzPlaylist).name : formatCustomTitle(settings.zipName, result as QobuzAlbum);
 
         await createJob(setStatusBar, formattedZipTitle, DiscAlbumIcon, async () => {
             return new Promise(async (resolve) => {
@@ -144,8 +147,22 @@ export const createDownloadJob = async (
                         !((settings.outputQuality === '27' && settings.outputCodec === 'FLAC') || (settings.bitrate === 320 && settings.outputCodec === 'MP3'))
                     )
                         await loadFFmpeg(ffmpegState, signal);
-                    setStatusBar((prev) => ({ ...prev, description: 'Fetching album data...' }));
-                    if (!fetchedAlbumData) {
+                    setStatusBar((prev) => ({ ...prev, description: isPlaylist ? 'Fetching playlist data...' : 'Fetching album data...' }));
+                    
+                    let playlistData: QobuzPlaylist | null = null;
+                    
+                    if (isPlaylist) {
+                        const playlistResponse = await axios.get('/api/get-playlist', {
+                            params: { playlist_id: (result as QobuzPlaylist).id },
+                            headers: { 'Token-Country': country },
+                            signal
+                        });
+                        if (playlistResponse.data.success && playlistResponse.data.data.playlists) {
+                            playlistData = playlistResponse.data.data.playlists.items[0];
+                        } else {
+                            playlistData = playlistResponse.data.data;
+                        }
+                    } else if (!fetchedAlbumData) {
                         const albumDataResponse = await axios.get('/api/get-album', {
                             params: { album_id: (result as QobuzAlbum).id },
                             headers: { 'Token-Country': country },
@@ -156,44 +173,131 @@ export const createDownloadJob = async (
                         }
                         fetchedAlbumData = albumDataResponse.data.data;
                     }
-                    const albumTracks = fetchedAlbumData!.tracks.items.map((track: QobuzTrack) => ({
-                        ...track,
-                        album: fetchedAlbumData
-                    })) as QobuzTrack[];
+                    
+                    const albumTracks = isPlaylist
+                        ? playlistData!.tracks.items.map((track: QobuzTrack) => {
+                            if (!track.album) {
+                                return {
+                                    ...track,
+                                    album: {
+                                        title: playlistData!.name,
+                                        artists: [],
+                                        artist: { name: track.performer?.name || 'Various Artists', id: 0, albums_count: 0, image: null }
+                                    } as any
+                                };
+                            }
+                            return track;
+                        })
+                        : fetchedAlbumData!.tracks.items.map((track: QobuzTrack) => ({
+                              ...track,
+                              album: fetchedAlbumData
+                          })) as QobuzTrack[];
+                    
                     let totalAlbumSize = 0;
-                    const albumUrls = [] as string[];
-                    setStatusBar((prev) => ({ ...prev, description: 'Fetching album size...' }));
-                    let currentDisk = 1;
-                    let trackOffset = 0;
+                    const trackUrlMap = new Map<number, string>();
+                    setStatusBar((prev) => ({ ...prev, description: isPlaylist ? 'Fetching playlist size...' : 'Fetching album size...' }));
+                    
                     for (const [index, track] of albumTracks.entries()) {
-                        if (track.streamable) {
-                            const fileURLResponse = await axios.get('/api/download-music', {
-                                params: { track_id: track.id, quality: settings.outputQuality },
-                                headers: { 'Token-Country': country },
-                                signal
-                            });
-                            const trackURL = fileURLResponse.data.data.url;
-                            if (!(currentDisk === track.media_number)) {
-                                trackOffset = albumUrls.length;
-                                currentDisk = track.media_number;
-                                albumUrls.push(trackURL);
-                            } else albumUrls[track.track_number + trackOffset - 1] = trackURL;
-                            const fileSizeResponse = await axios.head(trackURL, { signal });
-                            setStatusBar((statusBar) => ({
-                                ...statusBar,
-                                progress: (100 / albumTracks.length) * (index + 1)
-                            }));
-                            const fileSize = parseInt(fileSizeResponse.headers['content-length']);
-                            totalAlbumSize += fileSize;
+                        if (track && track.streamable) {
+                            try {
+                                const fileURLResponse = await axios.get('/api/download-music', {
+                                    params: { track_id: track.id, quality: settings.outputQuality },
+                                    headers: { 'Token-Country': country },
+                                    signal
+                                });
+                                const trackURL = fileURLResponse.data.data.url;
+                                trackUrlMap.set(index, trackURL);
+                                
+                                const fileSizeResponse = await axios.head(trackURL, { signal });
+                                setStatusBar((statusBar) => ({
+                                    ...statusBar,
+                                    progress: (100 / albumTracks.length) * (index + 1)
+                                }));
+                                const fileSize = parseInt(fileSizeResponse.headers['content-length']);
+                                totalAlbumSize += fileSize;
+                            } catch (e) {
+                                console.warn(`Failed to get URL for track ${index}:`, e);
+                            }
                         }
                     }
+                    
+                    // Fetch album art
+                    let albumArt: ArrayBuffer | false = false;
+                    if (isPlaylist) {
+                        const playlistImages = (result as QobuzPlaylist).images;
+                        if (playlistImages && playlistImages.length > 0) {
+                            try {
+                                const response = await axios.get(playlistImages[0], { responseType: 'arraybuffer', signal });
+                                albumArt = response.data;
+                            } catch (e) {
+                                console.warn('Failed to fetch playlist art:', e);
+                            }
+                        }
+                    } else {
+                        const albumArtURL = await resizeImage(getFullResImageUrl(fetchedAlbumData!), settings.albumArtSize, settings.albumArtQuality);
+                        if (albumArtURL) {
+                            try {
+                                const response = await axios.get(albumArtURL, { responseType: 'arraybuffer', signal });
+                                albumArt = response.data;
+                            } catch (e) {
+                                console.warn('Failed to fetch album art:', e);
+                            }
+                        }
+                    }
+                    
+                    // Check if playlist is too large for ZIP (>1.5GB)
+                    const estimatedZipSize = totalAlbumSize * 1.1;
+                    if (isPlaylist && estimatedZipSize > 1500000000) {
+                        // Download tracks individually for large playlists
+                        toast({
+                            title: 'Large Playlist',
+                            description: 'Downloading tracks individually due to size'
+                        });
+                        
+                        setStatusBar((prev) => ({ ...prev, progress: 0 }));
+                        let completed = 0;
+                        
+                        for (const [index, url] of trackUrlMap.entries()) {
+                            if (cancelled) break;
+                            const track = albumTracks[index];
+                            if (url && track) {
+                                try {
+                                    const response = await axios.get(url, { responseType: 'arraybuffer', signal });
+                                    let outputFile = await applyMetadata(response.data, track, ffmpegState, settings, undefined, albumArt);
+                                    if (settings.outputCodec === 'FLAC' && settings.fixMD5) {
+                                        outputFile = await (await fixMD5Hash(outputFile)).arrayBuffer();
+                                    }
+                                    const fileName = `${(index + 1).toString().padStart(2, '0')} ${formatCustomTitle(settings.trackName, track)}.${codecMap[settings.outputCodec].extension}`;
+                                    saveAs(URL.createObjectURL(new Blob([outputFile])), cleanFileName(fileName));
+                                    completed++;
+                                    setStatusBar((prev) => ({
+                                        ...prev,
+                                        progress: Math.floor((completed / trackUrlMap.size) * 100),
+                                        description: `Downloaded ${completed}/${trackUrlMap.size} tracks`
+                                    }));
+                                    await new Promise(r => setTimeout(r, 500));
+                                } catch (e) {
+                                    console.error(`Failed track ${index}:`, e);
+                                }
+                            }
+                        }
+                        
+                        if (albumArt !== false) {
+                            saveAs(URL.createObjectURL(new Blob([albumArt], { type: 'image/jpeg' })), 'cover.jpg');
+                        }
+                        
+                        setStatusBar((prev) => ({ ...prev, progress: 100 }));
+                        resolve();
+                        return;
+                    }
+                    
+                    // Download and ZIP for smaller playlists/albums
                     const trackBuffers = [] as ArrayBuffer[];
                     let totalBytesDownloaded = 0;
-                    setStatusBar((statusBar) => ({ ...statusBar, progress: 0, description: `Fetching album art...` }));
-                    const albumArtURL = await resizeImage(getFullResImageUrl(fetchedAlbumData!), settings.albumArtSize, settings.albumArtQuality);
-                    const albumArt = albumArtURL ? (await axios.get(albumArtURL, { responseType: 'arraybuffer' })).data : false;
-                    for (const [index, url] of albumUrls.entries()) {
-                        if (url) {
+                    setStatusBar((prev) => ({ ...prev, progress: 0 }));
+                    
+                    for (const [index, url] of trackUrlMap.entries()) {
+                        if (url && albumTracks[index]) {
                             const response = await axios.get(url, {
                                 responseType: 'arraybuffer',
                                 onDownloadProgress: (progressEvent) => {
@@ -210,31 +314,34 @@ export const createDownloadJob = async (
                                 },
                                 signal
                             });
-                            await new Promise((resolve) => setTimeout(resolve, 100));
+                            await new Promise((r) => setTimeout(r, 100));
                             totalBytesDownloaded += response.data.byteLength;
-                            const inputFile = response.data;
-                            let outputFile = await applyMetadata(
-                                inputFile,
-                                albumTracks[index],
-                                ffmpegState,
-                                settings,
-                                undefined,
-                                albumArt,
-                                fetchedAlbumData!.upc
-                            );
-                            if (settings.outputCodec === 'FLAC' && settings.fixMD5) outputFile = await (await fixMD5Hash(outputFile)).arrayBuffer();
-                            trackBuffers[index] = outputFile;
+                            const currentTrack = albumTracks[index];
+                            if (currentTrack) {
+                                let outputFile = await applyMetadata(
+                                    response.data,
+                                    currentTrack,
+                                    ffmpegState,
+                                    settings,
+                                    undefined,
+                                    albumArt,
+                                    isPlaylist ? undefined : fetchedAlbumData!.upc
+                                );
+                                if (settings.outputCodec === 'FLAC' && settings.fixMD5) outputFile = await (await fixMD5Hash(outputFile)).arrayBuffer();
+                                trackBuffers[index] = outputFile;
+                            }
                         }
                     }
-                    setStatusBar((statusBar) => ({ ...statusBar, progress: 0, description: `Zipping album...` }));
-                    await new Promise((resolve) => setTimeout(resolve, 500));
+                    
+                    setStatusBar((prev) => ({ ...prev, progress: 0, description: 'Creating ZIP...' }));
+                    await new Promise((r) => setTimeout(r, 500));
+                    
                     const zipFiles = {
-                        'cover.jpg': new Uint8Array(albumArt),
+                        ...(albumArt !== false ? { 'cover.jpg': new Uint8Array(albumArt) } : {}),
                         ...trackBuffers.reduce(
                             (acc, buffer, index) => {
                                 if (buffer) {
-                                    const fileName = `${(index + 1).toString().padStart(Math.max(String(albumTracks.length - 1).length, 2), '0')} ${formatCustomTitle(settings.trackName, albumTracks[index])}.${codecMap[settings.outputCodec].extension}`;
-
+                                    const fileName = `${(index + 1).toString().padStart(2, '0')} ${formatCustomTitle(settings.trackName, albumTracks[index])}.${codecMap[settings.outputCodec].extension}`;
                                     acc[cleanFileName(fileName)] = new Uint8Array(buffer);
                                 }
                                 return acc;
@@ -242,15 +349,11 @@ export const createDownloadJob = async (
                             {} as { [key: string]: Uint8Array }
                         )
                     } as { [key: string]: Uint8Array };
-                    if (albumArt === false) delete zipFiles['cover.jpg'];
+                    
                     const zippedFile = zipSync(zipFiles, { level: 0 });
                     const zipBlob = new Blob([zippedFile as BlobPart], { type: 'application/zip' });
                     setStatusBar((prev) => ({ ...prev, progress: 100 }));
-                    const objectURL = URL.createObjectURL(zipBlob);
-                    saveAs(objectURL, formattedZipTitle + '.zip');
-                    setTimeout(() => {
-                        URL.revokeObjectURL(objectURL);
-                    }, 100);
+                    saveAs(URL.createObjectURL(zipBlob), formattedZipTitle + '.zip');
                     resolve();
                 } catch (e) {
                     if (e instanceof AxiosError && e.code === 'ERR_CANCELED') resolve();
@@ -274,9 +377,7 @@ export const createDownloadJob = async (
 
 function proceedDownload(objectURL: string, title: string) {
     saveAs(objectURL, title);
-    setTimeout(() => {
-        URL.revokeObjectURL(objectURL);
-    }, 100);
+    setTimeout(() => URL.revokeObjectURL(objectURL), 100);
 }
 
 export async function downloadArtistDiscography(

--- a/lib/ffmpeg-functions.tsx
+++ b/lib/ffmpeg-functions.tsx
@@ -80,61 +80,78 @@ export async function applyMetadata(
     }
     if (!settings.applyMetadata) return trackBuffer;
     if (settings.outputCodec === 'WAV') return trackBuffer;
+    if (!resultData) return trackBuffer; // Safety check
     if (setStatusBar) setStatusBar((prev) => ({ ...prev, description: 'Applying metadata...' }));
-    const artists = resultData.album.artists === undefined ? [resultData.performer] : resultData.album.artists;
+    
+    // Build metadata string
     let metadata = `;FFMETADATA1`;
-    metadata += `\ntitle=${formatTitle(resultData)}`;
-    if (artists.length > 0) {
-        metadata += `\nartist=${formatArtists(resultData)}`;
-        metadata += `\nalbum_artist=${formatArtists(resultData)}`;
-    } else {
-        metadata += `\nartist=Various Artists`;
-        metadata += `\nalbum_artist=Various Artists`;
+    
+    // Title
+    const title = resultData.title || 'Unknown Track';
+    metadata += `\ntitle=${title}`;
+    
+    // Artist info
+    const artistName = resultData.performer?.name || 'Various Artists';
+    metadata += `\nartist=${artistName}`;
+    metadata += `\nalbum_artist=${artistName}`;
+    
+    // Album info - only if album exists
+    if (resultData.album) {
+        try {
+            metadata += `\nalbum=${formatTitle(resultData.album)}`;
+            if (resultData.album.genre) metadata += `\ngenre=${resultData.album.genre.name}`;
+            if (resultData.album.release_date_original) {
+                metadata += `\ndate=${resultData.album.release_date_original}`;
+                metadata += `\nyear=${new Date(resultData.album.release_date_original).getFullYear()}`;
+            }
+            const album = getAlbum(resultData);
+            if (album && album.label) metadata += `\nlabel=${album.label.name}`;
+        } catch (e) {
+            console.warn('Error adding album metadata:', e);
+        }
     }
-    metadata += `\nalbum_artist=${artists[0]?.name || resultData.performer?.name || 'Various Artists'}`;
-    metadata += `\nalbum=${formatTitle(resultData.album)}`;
-    metadata += `\ngenre=${resultData.album.genre.name}`;
-    metadata += `\ndate=${resultData.album.release_date_original}`;
-    metadata += `\nyear=${new Date(resultData.album.release_date_original).getFullYear()}`;
-    metadata += `\nlabel=${getAlbum(resultData).label.name}`;
-    metadata += `\ncopyright=${resultData.copyright}`;
+    
+    // Track info
+    if (resultData.copyright) metadata += `\ncopyright=${resultData.copyright}`;
     if (resultData.isrc) metadata += `\nisrc=${resultData.isrc}`;
     if (upc) metadata += `\nbarcode=${upc}`;
     if (resultData.track_number) metadata += `\ntrack=${resultData.track_number}`;
+    
     await ffmpeg.FS('writeFile', 'input.' + extension, new Uint8Array(trackBuffer));
     const encoder = new TextEncoder();
     await ffmpeg.FS('writeFile', 'metadata.txt', encoder.encode(metadata));
+    
+    // Handle album art
+    let hasAlbumArt = false;
     if (!(albumArt === false)) {
-        if (!albumArt) {
-            const albumArtURL = await resizeImage(getFullResImageUrl(resultData), settings.albumArtSize, settings.albumArtQuality);
-            if (albumArtURL) {
-                albumArt = (await axios.get(albumArtURL, { responseType: 'arraybuffer' })).data;
-            } else albumArt = false;
+        if (!albumArt && resultData.album) {
+            try {
+                const albumArtURL = await resizeImage(getFullResImageUrl(resultData), settings.albumArtSize, settings.albumArtQuality);
+                if (albumArtURL) {
+                    albumArt = (await axios.get(albumArtURL, { responseType: 'arraybuffer' })).data;
+                }
+            } catch (e) {
+                console.warn('Failed to fetch album art:', e);
+                albumArt = false;
+            }
         }
-        if (albumArt)
-            await ffmpeg.FS(
-                'writeFile',
-                'albumArt.jpg',
-                new Uint8Array(
-                    albumArt
-                        ? albumArt
-                        : (
-                              await axios.get((await resizeImage(getFullResImageUrl(resultData), settings.albumArtSize, settings.albumArtQuality)) as string, {
-                                  responseType: 'arraybuffer'
-                              })
-                          ).data
-                )
-            );
+        if (albumArt) {
+            await ffmpeg.FS('writeFile', 'albumArt.jpg', new Uint8Array(albumArt));
+            hasAlbumArt = true;
+        }
     }
 
     await ffmpeg.run('-i', 'input.' + extension, '-i', 'metadata.txt', '-map_metadata', '1', '-codec', 'copy', 'secondInput.' + extension);
-    if (['WAV', 'OPUS'].includes(settings.outputCodec) || albumArt === false) {
+    
+    if (['WAV', 'OPUS'].includes(settings.outputCodec) || !hasAlbumArt) {
         const output = await ffmpeg.FS('readFile', 'secondInput.' + extension);
         ffmpeg.FS('unlink', 'input.' + extension);
         ffmpeg.FS('unlink', 'metadata.txt');
         ffmpeg.FS('unlink', 'secondInput.' + extension);
+        if (hasAlbumArt) ffmpeg.FS('unlink', 'albumArt.jpg');
         return output;
     }
+    
     await ffmpeg.run(
         '-i',
         'secondInput.' + extension,

--- a/lib/qobuz-dl-server.tsx
+++ b/lib/qobuz-dl-server.tsx
@@ -8,6 +8,7 @@ import axios from 'axios';
 const QOBUZ_ALBUM_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/album\/[a-zA-Z0-9]+/;
 const QOBUZ_TRACK_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/track\/\d+/;
 const QOBUZ_ARTIST_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/artist\/\d+/;
+const QOBUZ_PLAYLIST_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/playlist\/\d+/;
 
 let crypto: any;
 let SocksProxyAgent: any;
@@ -34,9 +35,10 @@ export async function search(query: string, limit: number = 10, offset: number =
     const { country, ...requestOptions } = options || {};
     const token = country ? getTokenForCountry(country) : getRandomToken();
 
-    // Test if query is a Qobuz URL
+    // Test if query is a Qobuz URL or ID
     let id: string | null = null;
     let switchTo: string | null = null;
+    
     if (query.trim().match(QOBUZ_ALBUM_URL_REGEX)) {
         id = query.trim().match(QOBUZ_ALBUM_URL_REGEX)![0].replace('https://open', '').replace('https://play', '').replace('.qobuz.com/album/', '');
         switchTo = 'albums';
@@ -46,8 +48,23 @@ export async function search(query: string, limit: number = 10, offset: number =
     } else if (query.trim().match(QOBUZ_ARTIST_URL_REGEX)) {
         id = query.trim().match(QOBUZ_ARTIST_URL_REGEX)![0].replace('https://open', '').replace('https://play', '').replace('.qobuz.com/artist/', '');
         switchTo = 'artists';
+    } else if (query.trim().match(QOBUZ_PLAYLIST_URL_REGEX)) {
+        id = query.trim().match(QOBUZ_PLAYLIST_URL_REGEX)![0].replace('https://open', '').replace('https://play', '').replace('.qobuz.com/playlist/', '');
+        switchTo = 'playlists';
+        
+        // For playlists, fetch directly from playlist API
+        const playlistData = await getPlaylistInfo(id, options);
+        return {
+            query,
+            switchTo,
+            albums: { limit: 0, offset: 0, total: 0, items: [] },
+            tracks: { limit: 0, offset: 0, total: 0, items: [] },
+            artists: { limit: 0, offset: 0, total: 0, items: [] },
+            playlists: { limit: 1, offset: 0, total: 1, items: [playlistData] }
+        } as QobuzSearchResults;
     }
-    // Else, search Qobuz database for the song
+    
+    // Else, search Qobuz database
     const url = new URL(process.env.QOBUZ_API_BASE + 'catalog/search');
     url.searchParams.append('query', id || query);
     url.searchParams.append('limit', limit.toString());
@@ -66,6 +83,12 @@ export async function search(query: string, limit: number = 10, offset: number =
         httpsAgent: proxyAgent,
         ...requestOptions
     });
+    
+    // Add empty playlists array if not present
+    if (!response.data.playlists) {
+        response.data.playlists = { limit: 0, offset: 0, total: 0, items: [] };
+    }
+    
     return {
         ...response.data,
         switchTo
@@ -187,4 +210,34 @@ export async function getDownloadURL(trackID: number, quality: string, options?:
         ...requestOptions
     });
     return response.data.url;
+}
+export async function getPlaylistInfo(playlist_id: string, options?: APIOptionProps) {
+    testForRequirements();
+    const { country, ...requestOptions } = options || {};
+    const token = country ? getTokenForCountry(country) : getRandomToken();
+
+    const url = new URL(process.env.QOBUZ_API_BASE + 'playlist/get');
+    url.searchParams.append('playlist_id', playlist_id);
+    url.searchParams.append('extra', 'tracks');
+    url.searchParams.append('limit', '500');
+    
+    let proxyAgent = undefined;
+    if (process.env.SOCKS5_PROXY) {
+        proxyAgent = new SocksProxyAgent('socks5://' + process.env.SOCKS5_PROXY);
+    }
+    
+    const response = await axios.get(
+        process.env.CORS_PROXY ? process.env.CORS_PROXY + encodeURIComponent(url.toString()) : url.toString(),
+        {
+            headers: {
+                'x-app-id': process.env.QOBUZ_APP_ID!,
+                'x-user-auth-token': token,
+                'User-Agent': process.env.CORS_PROXY ? 'Qobuz-DL' : undefined
+            },
+            httpAgent: proxyAgent,
+            httpsAgent: proxyAgent,
+            ...requestOptions
+        }
+    );
+    return response.data;
 }

--- a/lib/qobuz-dl.tsx
+++ b/lib/qobuz-dl.tsx
@@ -120,6 +120,33 @@ export type QobuzSearchResults = {
         total: number;
         items: QobuzArtist[];
     };
+    playlists: {
+        limit: number;
+        offset: number;
+        total: number;
+        items: QobuzPlaylist[];
+    };
+};
+
+export type QobuzPlaylist = {
+    id: number;
+    name: string;
+    description: string | null;
+    images: string[];
+    duration: number;
+    tracks_count: number;
+    users_count: number;
+    is_public: boolean;
+    owner: {
+        id: number;
+        name: string;
+    };
+    tracks: {
+        offset: number;
+        limit: number;
+        total: number;
+        items: QobuzTrack[];
+    };
 };
 
 export type QobuzArtistResults = {
@@ -169,17 +196,23 @@ export type FilterDataType = {
     icon: LucideIcon;
 }[];
 
-export type QobuzSearchFilters = 'albums' | 'tracks' | 'artists';
+export type QobuzSearchFilters = 'albums' | 'tracks' | 'artists' | 'playlists';
 
 export const QOBUZ_ALBUM_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/album\/[a-zA-Z0-9]+/;
 export const QOBUZ_TRACK_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/track\/\d+/;
 export const QOBUZ_ARTIST_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/artist\/\d+/;
+export const QOBUZ_PLAYLIST_URL_REGEX = /https:\/\/(play|open)\.qobuz\.com\/playlist\/\d+/;
 
-export function getAlbum(input: QobuzAlbum | QobuzTrack | QobuzArtist) {
+export function getAlbum(input: QobuzAlbum | QobuzTrack | QobuzArtist | QobuzPlaylist) {
+    if ('owner' in input) return null;
     return ((input as QobuzAlbum).image ? input : (input as QobuzTrack).album) as QobuzAlbum;
 }
 
-export function formatTitle(input: QobuzAlbum | QobuzTrack | QobuzArtist) {
+export function formatTitle(input: QobuzAlbum | QobuzTrack | QobuzArtist | QobuzPlaylist) {
+    if (!input) return 'Unknown';
+    if ('owner' in input) {
+        return (input as QobuzPlaylist).name;
+    }
     return `${(input as QobuzAlbum | QobuzTrack).title ?? (input as QobuzArtist).name}${(input as QobuzAlbum | QobuzTrack).version ? ' (' + (input as QobuzAlbum | QobuzTrack).version + ')' : ''}`.trim();
 }
 
@@ -187,9 +220,14 @@ export function getFullResImageUrl(input: QobuzAlbum | QobuzTrack) {
     return getAlbum(input).image.large.substring(0, getAlbum(input).image.large.length - 7) + 'org.jpg';
 }
 
-export function formatArtists(input: QobuzAlbum | QobuzTrack, separator: string = ', ') {
-    return (getAlbum(input) as QobuzAlbum).artists && (getAlbum(input) as QobuzAlbum).artists.length > 0
-        ? (getAlbum(input) as QobuzAlbum).artists.map((artist) => artist.name).join(separator)
+export function formatArtists(input: QobuzAlbum | QobuzTrack | QobuzPlaylist, separator: string = ', ') {
+    if ('owner' in input) {
+        return (input as QobuzPlaylist).owner.name;
+    }
+    const album = getAlbum(input);
+    if (!album) return 'Various Artists';
+    return (album as QobuzAlbum).artists && (album as QobuzAlbum).artists.length > 0
+        ? (album as QobuzAlbum).artists.map((artist) => artist.name).join(separator)
         : (input as QobuzTrack).performer?.name || 'Various Artists';
 }
 
@@ -263,4 +301,15 @@ export async function getFullAlbumInfo(
     const albumDataResponse = await axios.get('/api/get-album', { params: { album_id: (result as QobuzAlbum).id }, headers: { 'Token-Country': country } });
     setFetchedAlbumData(albumDataResponse.data.data);
     return albumDataResponse.data.data;
+}
+
+export async function getPlaylistInfo(
+    playlist_id: string,
+    country?: string
+): Promise<QobuzPlaylist> {
+    const response = await axios.get('/api/get-playlist', {
+        params: { playlist_id },
+        headers: { 'Token-Country': country }
+    });
+    return response.data.data;
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,33 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+    images: {
+        remotePatterns: [
+            {
+                protocol: 'https',
+                hostname: 'static.qobuz.com',
+                port: '',
+                pathname: '**',
+                search: ''
+            }
+        ]
+    },
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: [
+                    {
+                        key: 'Cross-Origin-Opener-Policy',
+                        value: 'same-origin'
+                    },
+                    {
+                        key: 'Cross-Origin-Embedder-Policy',
+                        value: 'require-corp'
+                    }
+                ]
+            }
+        ];
+    }
+};
+
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2747,7 +2747,8 @@
                 }
             ],
             "hasInstallScript": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@tsparticles/interaction-external-attract": {
             "version": "3.7.1",
@@ -4325,6 +4326,7 @@
             "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -4335,6 +4337,7 @@
             "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.0.0"
             }
@@ -4375,6 +4378,7 @@
             "integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.18.1",
                 "@typescript-eslint/types": "8.18.1",
@@ -4581,6 +4585,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5603,6 +5608,7 @@
             "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5824,6 +5830,7 @@
             "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.8",
@@ -7141,6 +7148,7 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -7902,6 +7910,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.1.1",
@@ -8042,6 +8051,7 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -8115,6 +8125,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
             "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8136,6 +8147,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
             "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.25.0"
             },
@@ -8999,6 +9011,7 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -9281,6 +9294,7 @@
             "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Stop any running server
+echo "Stopping server..."
+
+# Remove .next cache
+echo "Removing .next cache..."
+rm -rf .next
+
+# Remove old config
+echo "Removing old config..."
+rm -f next.config.ts
+
+# Restart server
+echo "Starting server..."
+npm run dev


### PR DESCRIPTION
- Add playlist download functionality
- Support for large playlists (>1.5GB) with individual track downloads
- Individual album art for each track in playlists
- Full metadata support for playlist tracks
- Smart size detection (ZIP for small, individual files for large)
- New API route: /api/get-playlist
- Updated UI with Playlists filter
- Works with both public and private playlists